### PR TITLE
Fixed 'accessed before initialization' PHP error

### DIFF
--- a/Model/Email.php
+++ b/Model/Email.php
@@ -16,7 +16,7 @@ class Email
     /**
      * @var string
      */
-    private string $domain;
+    private ?string $domain = null;
 
     /**
      * @param string $email
@@ -43,9 +43,9 @@ class Email
      */
     private function getDomain(): ?string
     {
-        if (!$this->domain) {
+        if ($this->domain === null) {
             $domainParts = explode('@', $this->email);
-            $this->domain = $domainParts[1] ?? null;
+            $this->domain = $domainParts[1] ?? '';
         }
 
         return $this->domain;


### PR DESCRIPTION
The current version causes an error on recent PHP versions:

```
Error: Typed property LucidModules\CustomerGuard\Model\Email::$domain must not be accessed before initialization in vendor/lucid-modules/module-customer-guard/Model/Email.php:46
```

This fixes it.